### PR TITLE
Do not trim nicknames at ~

### DIFF
--- a/src/c_user.c
+++ b/src/c_user.c
@@ -546,7 +546,7 @@ static void m_list(conn, msg) u_conn *conn; u_msg *msg;
 static void m_nick(conn, msg) u_conn *conn; u_msg *msg;
 {
 	u_user *u = conn->priv;
-	char *s, *newnick = msg->argv[0];
+	char *newnick = msg->argv[0];
 
 	/* cut newnick to nicklen */
 	if (strlen(newnick) > MAXNICKLEN)
@@ -556,13 +556,6 @@ static void m_nick(conn, msg) u_conn *conn; u_msg *msg;
 		u_user_num(u, ERR_ERRONEOUSNICKNAME, newnick);
 		return;
 	}
-
-	/* due to the scandalous origins, (~ being uppercase of ^) and ~
-	 * being disallowed as a nick char, we need to chop the first ~
-	 * instead of just erroring.
-	 */ 
-	if ((s = strchr(newnick, '~')))
-		*s = '\0';
 
 	/* Check for case change */
 	if (irccmp(u->nick, newnick) && u_user_by_nick(newnick)) {


### PR DESCRIPTION
As seen in my Charybdis pull request atheme/charybdis#17 (which you fixed yourself, by the way)...

> First, it's 2013 and I'd be really surprised if anybody still cared
> about ISO-646 support these days.
> 
> Second, ISO-646-FI, which the "scandinavian origins" probably refers
> to, did NOT have any letters in place of ~ or ^; it had the same ~ ^
> and so did all other Scandinavian ISO-646 charsets.  The only
> exception here is ISO-646-SE-C, which had Ü ü in those places, but it
> also had É é in place of @ `, so by this logic the code should
> disallow` as well.
> 
> Fuck that. If this patch hurts ISO-646 users, that's a feature.
