### PR TITLE
Remove ~ ^ from case mapping

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -406,7 +406,6 @@ int init_util()
 	rfc1459_casemap['['] = '{';
 	rfc1459_casemap[']'] = '}';
 	rfc1459_casemap['\\'] = '|';
-	rfc1459_casemap['~'] = '^';
 
 	return 0;
 }


### PR DESCRIPTION
These are only equivalent in RFC 2812, not in RFC 1459.

> 2.2 Character codes
> 
>    Because of IRC's scandanavian origin, the characters `{}|` are
>    considered to be the lower case equivalents of the characters `[]\`,
>    respectively.
